### PR TITLE
#1000 adding  param in constructor so that the  data is passed to par…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "magento/framework": "*",
-        "scandipwa/locale": "^1",
+        "scandipwa/locale": "^1.2",
         "magento/module-config": "*",
         "magento/module-cms": "*",
         "magento/module-eav": "*",

--- a/src/View/Result/Page.php
+++ b/src/View/Result/Page.php
@@ -68,6 +68,7 @@ class Page extends LocalePage
      * @param bool $isIsolated
      * @param EntitySpecificHandlesList|null $entitySpecificHandlesList
      * @param null $action
+     * @param array $rootTemplatePool
      */
     public function __construct(
         StoreManagerInterface $storeManager,
@@ -84,7 +85,8 @@ class Page extends LocalePage
         string $template,
         $isIsolated = false,
         EntitySpecificHandlesList $entitySpecificHandlesList = null,
-        $action = null
+        $action = null,
+        $rootTemplatePool = []
     ) {
         $this->scopeConfig = $context->getScopeConfig();
         $this->storeManager = $storeManager;
@@ -103,7 +105,8 @@ class Page extends LocalePage
             $template,
             $isIsolated,
             $entitySpecificHandlesList,
-            $action
+            $action,
+            $rootTemplatePool
         );
     }
 


### PR DESCRIPTION
…ent Page Class
ref: https://github.com/scandipwa/locale/pull/1
due to the  \ScandiPWA\Locale\View\Result\Page has been overridden by \ScandiPWA\Customization\View\Result\Page the $rootTemplatePool is passed to parent by the \ScandiPWA\Customization\View\Result\Page's constructor As the root template has been passed via dependency injection in https://github.com/scandipwa/route717/pull/13