### PR TITLE
#1392 Favicon change through admin / M2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Adds *ScandiPWA* tab in the Store configuration. Adds color and content configur
 - Product card displayed attribute selection
 - Main menu switcher
 - Cookie popup content
+- Webmanifest content
+- Favicon

--- a/src/Controller/AppIcon.php
+++ b/src/Controller/AppIcon.php
@@ -101,7 +101,7 @@ class AppIcon
                 $width = is_array($size) ? $size[0] : $size;
                 $height = is_array($size) ? $size[1] : $size;
                 $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
-                $src = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::STORAGE_PATH) . $name . '.png';
+                $src = 'pub/media/' . self::STORAGE_PATH . $name . '.png';
                 $output[] = [
                     'src' => $src,
                     'type' => 'image/png',
@@ -129,9 +129,9 @@ class AppIcon
                 $height = is_array($size) ? $size[1] : $size;
                 $size = $width . 'x' . $height;
                 $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
-                $src = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::STORAGE_PATH) . $name . '.png';
+                $href = 'pub/media/' . self::STORAGE_PATH . $name . '.png';
                 $output[$targetPath][$size] = [
-                    'href' => $src,
+                    'href' => $href,
                     'sizes' => $size
                 ];
             }

--- a/src/Controller/AppIcon.php
+++ b/src/Controller/AppIcon.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Controller;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Image\AdapterFactory;
+
+/**
+ * Class AppIcon
+ * @package ScandiPWA\Customization\Controller
+ */
+class AppIcon
+{
+    const REFERENCE_IMAGE_PATH = 'favicon/favicon.png';
+
+    const STORAGE_PATH = 'favicon/icons/';
+
+    const IMAGE_RESIZING_CONFIG = [
+        'apple' => [
+            'type' => 'ios',
+            'sizes' => [120, 152, 167, 180, 1024]
+        ],
+        'apple_startup' => [
+            'type' => 'ios_startup',
+            'sizes' => [2048, 1668, 1536, 1125, 1242, 750, 640]
+        ],
+        'android' => [
+            'type' => 'android',
+            'sizes' => [36, 48, 72, 96, 144, 192, 512]
+        ]
+    ];
+
+    /**
+     * @var Filesystem
+     */
+    protected $fileSystem;
+
+    /**
+     * @var AdapterFactory
+     */
+    protected $imageFactory;
+
+    /**
+     * AppIcon constructor.
+     * @param Filesystem $fileSystem
+     * @param AdapterFactory $imageFactory
+     */
+    public function __construct(
+        Filesystem $fileSystem,
+        AdapterFactory $imageFactory
+    )
+    {
+        $this->imageFactory = $imageFactory;
+        $this->fileSystem = $fileSystem;
+    }
+
+    /**
+     * @param string $name
+     * @param int $width
+     * @param int $height
+     * @param string $absolutePath
+     * @return bool
+     */
+    protected function saveImage ($name, $width, $height, $absolutePath)
+    {
+        $imageResizedDir = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::STORAGE_PATH) . $name . '.png';
+
+        $imageResize = $this->imageFactory->create();
+        $imageResize->open($absolutePath);
+        $imageResize->constrainOnly(true);
+        $imageResize->keepTransparency(true);
+        $imageResize->keepFrame(false);
+        $imageResize->keepAspectRatio(false);
+        $imageResize->resize($width,$height);
+
+        try {
+            $imageResize->save($imageResizedDir);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIconData ()
+    {
+        $output = [];
+        foreach (self::IMAGE_RESIZING_CONFIG as $config) {
+            foreach ($config['sizes'] as $size) {
+                $width = is_array($size) ? $size[0] : $size;
+                $height = is_array($size) ? $size[1] : $size;
+                $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
+                $src = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::STORAGE_PATH) . $name . '.png';
+                $output[] = [
+                    'src' => $src,
+                    'type' => 'image/png',
+                    'size' => $width . 'x' . $height
+                ];
+            }
+        }
+        return $output;
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getIconLinks ()
+    {
+        $output = [
+            'icon' => [],
+            'ios_startup' => []
+        ];
+
+        foreach (self::IMAGE_RESIZING_CONFIG as $type => $config) {
+            $targetPath = $type === 'apple_startup' ? 'ios_startup' : 'icon';
+            foreach (self::IMAGE_RESIZING_CONFIG[1]['sizes'] as $size) {
+                $width = is_array($size) ? $size[0] : $size;
+                $height = is_array($size) ? $size[1] : $size;
+                $size = $width . 'x' . $height;
+                $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
+                $src = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::STORAGE_PATH) . $name . '.png';
+                $output[$targetPath][$size] = [
+                    'href' => $src,
+                    'sizes' => $size
+                ];
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return bool
+     */
+    public function buildAppIcons () {
+        $absolutePath = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath(self::REFERENCE_IMAGE_PATH);
+
+        if (!file_exists($absolutePath))
+            return false;
+
+        foreach (self::IMAGE_RESIZING_CONFIG as $config) {
+            foreach ($config['sizes'] as $size) {
+                $width = is_array($size) ? $size[0] : $size;
+                $height = is_array($size) ? $size[1] : $size;
+                $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
+                $this->saveImage($name, $width, $height, $absolutePath);
+            }
+        }
+    }
+}

--- a/src/Controller/AppIcon.php
+++ b/src/Controller/AppIcon.php
@@ -124,7 +124,7 @@ class AppIcon
 
         foreach (self::IMAGE_RESIZING_CONFIG as $type => $config) {
             $targetPath = $type === 'apple_startup' ? 'ios_startup' : 'icon';
-            foreach (self::IMAGE_RESIZING_CONFIG[1]['sizes'] as $size) {
+            foreach ($config['sizes'] as $size) {
                 $width = is_array($size) ? $size[0] : $size;
                 $height = is_array($size) ? $size[1] : $size;
                 $size = $width . 'x' . $height;

--- a/src/Controller/Webmanifest.php
+++ b/src/Controller/Webmanifest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Controller;
+
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+/**
+ * Class Webmanifest
+ * @package ScandiPWA\Customization\Controller
+ */
+class Webmanifest
+{
+    const WEBMANIFEST_CONFIG_PATH = 'webmanifest_customization/webmanifest/';
+
+    const STORAGE_PATH = 'webmanifest/manifest.webmanifest';
+
+    const ALLOWED_FIELDS = [
+        'name',
+        'short_name',
+        'description',
+        'background_color',
+        'lang',
+        'theme_color',
+        'start_url',
+        'orientation',
+        'display',
+        'categories',
+        'dir',
+        'iarc_rating_id',
+        'icons',
+        'prefer_related_applications',
+        'related_applications',
+        'scope',
+        'screenshots',
+        'serviceworker',
+        'shortcuts'
+    ];
+
+    /**
+     * @var WriterInterface
+     */
+    protected $writer;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var Filesystem
+     */
+    protected $fileSystem;
+
+    /**
+     * Webmanifest constructor.
+     * @param WriterInterface $writer
+     * @param ScopeConfigInterface $scopeConfig
+     * @param Filesystem $fileSystem
+     */
+    public function __construct(
+        WriterInterface $writer,
+        ScopeConfigInterface $scopeConfig,
+        Filesystem $fileSystem
+    )
+    {
+        $this->writer = $writer;
+        $this->scopeConfig = $scopeConfig;
+        $this->fileSystem = $fileSystem;
+    }
+
+    /**
+     * @param array $data
+     * @return false|string
+     */
+    protected function getGeneratedJson(array $data)
+    {
+        $arrayKeys = array_keys($data);
+        if (empty($arrayKeys))
+            return false;
+
+        $unSupportedKeys = array_filter($arrayKeys, function ($key) {
+            return !in_array($key, self::ALLOWED_FIELDS);
+        });
+
+        foreach ($unSupportedKeys as $unSupportedKey) {
+            unset($data[$unSupportedKey]);
+        }
+
+        return json_encode($data);
+    }
+
+    /**
+     * @param array $data
+     * @throws FileSystemException
+     */
+    public function saveJson(array $data)
+    {
+        $jsonData = $this->getGeneratedJson($data);
+
+        if (!$jsonData || empty($data))
+            return;
+
+        $fileWriter = $this->fileSystem->getDirectoryWrite(DirectoryList::MEDIA);
+
+        $fileWriter->writeFile(self::STORAGE_PATH, $jsonData);
+    }
+
+    /**
+     * @return array
+     */
+    public function load()
+    {
+        $data = [];
+        foreach (self::ALLOWED_FIELDS as $field) {
+            $value = $this->scopeConfig->getValue(self::WEBMANIFEST_CONFIG_PATH . $field);
+            if (!empty($value)) {
+                if (in_array($field, ['background_color', 'theme_color'])) {
+                    $value = '#' . $value;
+                }
+                $data[$field] = $value;
+            }
+
+        }
+        return $data;
+    }
+}

--- a/src/Model/Design/Backend/Favicon.php
+++ b/src/Model/Design/Backend/Favicon.php
@@ -9,11 +9,13 @@
 
 namespace ScandiPWA\Customization\Model\Design\Backend;
 
-use  ScandiPWA\Customization\Controller\AppIcon;
+use ScandiPWA\Customization\Controller\AppIcon;
 use Magento\Config\Model\Config\Backend\File\RequestData\RequestDataInterface;
 use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Model\Context;
@@ -104,6 +106,8 @@ class Favicon extends SourceFavicon
         $values = $this->getValue();
         $value = reset($values) ?: [];
 
+        $this->createFaviconDirectory();
+
         // Need to check name when it is uploaded in the media gallery
         $file = $value['file'] ?? $value['name'] ?? null;
         if (!isset($file)) {
@@ -120,6 +124,19 @@ class Favicon extends SourceFavicon
         $this->updateMediaDirectory(basename($file), $value['url']);
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     * @throws FileSystemException
+     */
+    protected function createFaviconDirectory() {
+        $directoryWriter = $this->_filesystem->getDirectoryWrite(DirectoryList::MEDIA);
+        try {
+            return $directoryWriter->create('favicon');
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Model/Design/Backend/Favicon.php
+++ b/src/Model/Design/Backend/Favicon.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Model\Design\Backend;
+
+use  ScandiPWA\Customization\Controller\AppIcon;
+use Magento\Config\Model\Config\Backend\File\RequestData\RequestDataInterface;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Magento\Framework\UrlInterface;
+use Magento\MediaStorage\Helper\File\Storage\Database;
+use Magento\MediaStorage\Model\File\UploaderFactory;
+use Magento\Theme\Model\Design\Backend\Favicon as SourceFavicon;
+
+/**
+ * Class Favicon
+ * @package ScandiPWA\Customization\Model\Design\Backend
+ */
+class Favicon extends SourceFavicon
+{
+    /**
+     * @var AppIcon
+     */
+    protected $appIcon;
+
+    /**
+     * @var Database
+     */
+    protected $databaseHelper;
+
+    /**
+     * Favicon constructor.
+     * @param Context $context
+     * @param Registry $registry
+     * @param ScopeConfigInterface $config
+     * @param TypeListInterface $cacheTypeList
+     * @param UploaderFactory $uploaderFactory
+     * @param RequestDataInterface $requestData
+     * @param Filesystem $filesystem
+     * @param UrlInterface $urlBuilder
+     * @param AppIcon $appIcon
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
+     * @param array $data
+     * @param Database|null $databaseHelper
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        UploaderFactory $uploaderFactory,
+        RequestDataInterface $requestData,
+        Filesystem $filesystem,
+        UrlInterface $urlBuilder,
+        AppIcon $appIcon,
+        Database $databaseHelper,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
+        array $data = []
+    ){
+        $this->appIcon = $appIcon;
+        $this->databaseHelper = $databaseHelper;
+        parent::__construct($context, $registry, $config, $cacheTypeList, $uploaderFactory, $requestData, $filesystem, $urlBuilder, $resource, $resourceCollection, $data, $databaseHelper);
+    }
+
+    /**
+     * @return string
+     */
+    protected function _getUploadDir() {
+        return $this->_mediaDirectory->getRelativePath(self::UPLOAD_DIR);
+    }
+
+    /**
+     * Generates webmanifest icons
+     * 
+     * @return Favicon
+     */
+    public function afterSave() {
+        $result = parent::afterSave();
+        $this->appIcon->buildAppIcons();
+        return $result;
+    }
+
+    /**
+     * Save uploaded file and remote temporary file before saving config value
+     *
+     * @return $this
+     * @throws LocalizedException
+     */
+    public function beforeSave() {
+        $values = $this->getValue();
+        $value = reset($values) ?: [];
+
+        // Need to check name when it is uploaded in the media gallery
+        $file = $value['file'] ?? $value['name'] ?? null;
+        if (!isset($file)) {
+            throw new LocalizedException(
+                __('%1 does not contain field \'file\'', $this->getData('field_config/field'))
+            );
+        }
+        if (isset($value['exists'])) {
+            $this->setValue($file);
+            return $this;
+        }
+
+        //phpcs:ignore Magento2.Functions.DiscouragedFunction
+        $this->updateMediaDirectory(basename($file), $value['url']);
+
+        return $this;
+    }
+
+    /**
+     * Move file to the correct media directory
+     *
+     * @param string $filename
+     * @param string $url
+     * @throws LocalizedException
+     */
+    private function updateMediaDirectory(string $filename, string $url) {
+        $relativeMediaPath = $this->getRelativeMediaPath($url);
+        $tmpMediaPath = $this->getTmpMediaPath($filename);
+        $mediaPath = $this->_mediaDirectory->isFile($relativeMediaPath) ? $relativeMediaPath : $tmpMediaPath;
+        $destinationMediaPath = $this->_getUploadDir() . '/favicon.png';
+
+        $result = $mediaPath === $destinationMediaPath;
+        if (!$result) {
+
+            $result = $this->_mediaDirectory->copyFile(
+                $mediaPath,
+                $destinationMediaPath
+            );
+            $this->databaseHelper->renameFile(
+                $mediaPath,
+                $destinationMediaPath
+            );
+        }
+        if ($result) {
+            if ($mediaPath === $tmpMediaPath) {
+                $this->_mediaDirectory->delete($mediaPath);
+            }
+            if ($this->_addWhetherScopeInfo()) {
+                $filename = $this->_prependScopeInfo($filename);
+            }
+
+            $this->setValue($filename);
+        } else {
+            $this->unsValue();
+        }
+    }
+
+    /**
+     * Getter for allowed extensions of uploaded files.
+     *
+     * @return string[]
+     */
+    public function getAllowedExtensions()
+    {
+        return ['png'];
+    }
+}

--- a/src/Model/Webmanifest/Source/Display.php
+++ b/src/Model/Webmanifest/Source/Display.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Model\Webmanifest\Source;
+
+use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ * Class Display
+ * @package ScandiPWA\Customization\Model\Webmanifest\Source
+ */
+class Display extends AbstractSource
+{
+    /**
+     * Retrieve All options
+     *
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function getAllOptions()
+    {
+        return [
+            ['value' => 'fullscreem', 'label' => __('Fullscreen')],
+            ['value' => 'standalone', 'label' => __('Standalone')],
+            ['value' => 'minimal-ui', 'label' => __('Minimal UI')],
+            ['value' => 'browser', 'label' => __('Browser')],
+        ];
+    }
+}

--- a/src/Model/Webmanifest/Source/Orientation.php
+++ b/src/Model/Webmanifest/Source/Orientation.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Model\Webmanifest\Source;
+
+use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
+
+/**
+ * Class Orientation
+ * @package ScandiPWA\Customization\Model\Webmanifest\Source
+ */
+class Orientation extends AbstractSource
+{
+    /**
+     * Retrieve All options
+     *
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function getAllOptions()
+    {
+        return [
+            ['value' => 'any', 'label' => __('Any')],
+            ['value' => 'natural', 'label' => __('Natural')],
+            ['value' => 'landscape', 'label' => __('Landscape')],
+            ['value' => 'landscape-primary', 'label' => __('Landscape Primary')],
+            ['value' => 'landscape-secondary', 'label' => __('Landscape Secondary')],
+            ['value' => 'portrait', 'label' => __('Portrait')],
+            ['value' => 'portrait-primary', 'label' => __('Portrait Primary')],
+            ['value' => 'portrait-secondary', 'label' => __('Portrait Secondary')],
+        ];
+    }
+}

--- a/src/Observer/Webmanifest.php
+++ b/src/Observer/Webmanifest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use ScandiPWA\Customization\Controller\Webmanifest as WebmanifestController;
+use ScandiPWA\Customization\Controller\AppIcon;
+
+/**
+ * Class Webmanifest
+ * @package ScandiPWA\Customization\Observer
+ */
+class Webmanifest implements ObserverInterface
+{
+    /**
+     * @var WebmanifestController
+     */
+    protected $webmanifestController;
+
+    protected $appIcon;
+
+    public function __construct(
+        WebmanifestController $webmanifestController,
+        AppIcon $appIcon
+    )
+    {
+        $this->webmanifestController = $webmanifestController;
+        $this->appIcon = $appIcon;
+    }
+
+    /**
+     * @param Observer $observer
+     * @throws NoSuchEntityException
+     */
+    public function execute(Observer $observer)
+    {
+        $data = $this->webmanifestController->load();
+        $data['icons'] = $this->appIcon->getIconData();
+        $this->webmanifestController->saveJson($data);
+    }
+}

--- a/src/etc/adminhtml/events.xml
+++ b/src/etc/adminhtml/events.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="admin_system_config_changed_section_webmanifest_customization">
+        <observer name="webmanifest_generator" instance="ScandiPWA\Customization\Observer\Webmanifest" />
+    </event>
+</config>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -16,5 +16,6 @@
         </tab>
         <include path="ScandiPWA_Customization::system/colors.xml"/>
         <include path="ScandiPWA_Customization::system/content.xml"/>
+        <include path="ScandiPWA_Customization::system/webmanifest.xml"/>
     </system>
 </config>

--- a/src/etc/adminhtml/system/webmanifest.xml
+++ b/src/etc/adminhtml/system/webmanifest.xml
@@ -18,61 +18,50 @@
         <group id="webmanifest" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
             <field id="name" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Name</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="short_name" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Short Name</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="description" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Description</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="lang" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Language</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="theme_color" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Theme Color</label>
                 <frontend_model>ScandiPWA\Customization\Block\Adminhtml\Config\Color</frontend_model>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="background_color" translate="label" type="text" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Background Color</label>
                 <frontend_model>ScandiPWA\Customization\Block\Adminhtml\Config\Color</frontend_model>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="start_url" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Start URL</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="orientation" translate="label" type="select" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Orientation</label>
                 <source_model>ScandiPWA\Customization\Model\Webmanifest\Source\Orientation</source_model>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="display" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Display</label>
                 <source_model>ScandiPWA\Customization\Model\Webmanifest\Source\Display</source_model>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="iarc_rating_id" translate="label" type="text" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>International Age Rating Coalition (IARC) ID</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
 
             <field id="scope" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Scope</label>
-                <comment>The block displayed in the footer (above copyright notice).</comment>
             </field>
         </group>
     </section>

--- a/src/etc/adminhtml/system/webmanifest.xml
+++ b/src/etc/adminhtml/system/webmanifest.xml
@@ -16,6 +16,9 @@
         <resource>ScandiPWA_Customization::scandipwa_config</resource>
 
         <group id="webmanifest" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>PWA web-manifest configuration</label>
+            <comment>Learn more about web-manifests fields on MDN. https://developer.mozilla.org/en-US/docs/Web/Manifest</comment>
+
             <field id="name" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Name</label>
             </field>

--- a/src/etc/adminhtml/system/webmanifest.xml
+++ b/src/etc/adminhtml/system/webmanifest.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Rihards Abolins <info@scandiweb.com>
+ * @author Teodor Moquist <tm@scandesignmedia.com>
+ * @copyright Copyright (c) 2015 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <section id="webmanifest_customization" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="0" showInStore="0">
+        <label>Webmanifest customization</label>
+        <tab>scandipwa</tab>
+        <resource>ScandiPWA_Customization::scandipwa_config</resource>
+
+        <group id="webmanifest" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+            <field id="name" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Name</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="short_name" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Short Name</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="description" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Description</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="lang" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Language</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="theme_color" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Theme Color</label>
+                <frontend_model>ScandiPWA\Customization\Block\Adminhtml\Config\Color</frontend_model>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="background_color" translate="label" type="text" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Background Color</label>
+                <frontend_model>ScandiPWA\Customization\Block\Adminhtml\Config\Color</frontend_model>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="start_url" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Start URL</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="orientation" translate="label" type="select" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Orientation</label>
+                <source_model>ScandiPWA\Customization\Model\Webmanifest\Source\Orientation</source_model>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="display" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Display</label>
+                <source_model>ScandiPWA\Customization\Model\Webmanifest\Source\Display</source_model>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="iarc_rating_id" translate="label" type="text" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>International Age Rating Coalition (IARC) ID</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+
+            <field id="scope" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Scope</label>
+                <comment>The block displayed in the footer (above copyright notice).</comment>
+            </field>
+        </group>
+    </section>
+</include>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -29,5 +29,18 @@
         <content_customization>
 
         </content_customization>
+        <webmanifest_customization>
+            <webmanifest>
+                <name>ScandiPWA</name>
+                <short_name>ScandiPWA</short_name>
+                <description>ScandiPWA theme DEMO store</description>
+                <background_color>ffffff</background_color>
+                <lang>en-US</lang>
+                <theme_color>ffffff</theme_color>
+                <start_url>/</start_url>
+                <display>standalone</display>
+                <orientation>portrait</orientation>
+            </webmanifest>
+        </webmanifest_customization>
     </default>
 </config>


### PR DESCRIPTION
Original issue: [#1392](https://github.com/scandipwa/base-theme/issues/1392)

## Requirements:
- Implement support for the favicon change from Magento admin
    WHERE TO FIND THE SETTING:
    admin->content->configuration->store view->HTML head->favicon icon

- Make sure favicon.ico is deprecated and png from admin is used instead

## Features
- Replaces NodeJs module WebPwaManifest with custom Magento 2 based support, as original implementation caused issues when favicon file was missing and generated manifest data based on config file only on redeploy.
- Generates manifest file based on back-end config
- Generates manifest icons based on favicon.
