### PR TITLE
#1392 Typo fix for "fullsreen"

### DIFF
--- a/src/Model/Webmanifest/Source/Display.php
+++ b/src/Model/Webmanifest/Source/Display.php
@@ -27,7 +27,7 @@ class Display extends AbstractSource
     public function getAllOptions()
     {
         return [
-            ['value' => 'fullscreem', 'label' => __('Fullscreen')],
+            ['value' => 'fullscreen', 'label' => __('Fullscreen')],
             ['value' => 'standalone', 'label' => __('Standalone')],
             ['value' => 'minimal-ui', 'label' => __('Minimal UI')],
             ['value' => 'browser', 'label' => __('Browser')],


### PR DESCRIPTION
Fixed typo for full-screen display mode from "fullscreem" to "fullscreen"