### PR TITLE
Bump require locale version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "magento/framework": "*",
-        "scandipwa/locale": "^1.2",
+        "scandipwa/locale": "^2",
         "magento/module-config": "*",
         "magento/module-cms": "*",
         "magento/module-eav": "*",


### PR DESCRIPTION
scandipwa/scandipwa require locale to be ^2.
This leads to conflict since scandipwa/customization require locale to be ^1.2