### PR TITLE
Icon url fixes

### DIFF
--- a/src/Controller/AppIcon.php
+++ b/src/Controller/AppIcon.php
@@ -130,7 +130,7 @@ class AppIcon
                 $height = is_array($size) ? $size[1] : $size;
                 $size = $width . 'x' . $height;
                 $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
-                $href = 'pub/media/' . self::STORAGE_PATH . $name . '.png';
+                $href = '/pub/media/' . self::STORAGE_PATH . $name . '.png';
                 $output[$type][$size] = [
                     'href' => $href,
                     'sizes' => $size

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -40,6 +40,7 @@
                 <start_url>/</start_url>
                 <display>standalone</display>
                 <orientation>portrait</orientation>
+                <scope>/</scope>
             </webmanifest>
         </webmanifest_customization>
     </default>


### PR DESCRIPTION
Fixed icon url so they are not relative to any added store code or category resulting a load error.