### PR TITLE
remove pub/ from icons URLs

### DIFF
--- a/src/Controller/AppIcon.php
+++ b/src/Controller/AppIcon.php
@@ -146,7 +146,7 @@ class AppIcon
                 $height = is_array($size) ? $size[1] : $size;
                 $size = $width . 'x' . $height;
                 $name = 'icon_' . $config['type'] . '_' . $width . 'x' . $height;
-                $href = '/pub/media/' . self::STORAGE_PATH . $name . '.png';
+                $href = '/media/' . self::STORAGE_PATH . $name . '.png';
                 $output[$type][$size] = [
                     'href' => $href,
                     'sizes' => $size


### PR DESCRIPTION
Both Magento and ScandiPWA documentations recommend setting the webroot to the /pub directory.

Therefore generating the icons URLs with 'pub/' will result in 404 errors when the webroot is properly set.

This PR addresses this issue by removing 'pub/' from icons URLs.