### PR TITLE
Display ScandiPWA theme version in adminhtml footer

### DIFF
--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Aleksandrs Kondratjevs <info@scandiweb.com>
+ * @copyright Copyright (c) 2021 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+
+namespace ScandiPWA\Customization\Block\Page;
+
+use Magento\Backend\Block\Page\Footer as CoreFooter;
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\View\Design\Theme\ListInterface;
+
+class Footer extends CoreFooter
+{
+    const PACKAGE_JSON_FILE = 'package.json';
+
+    /**
+     * ScandiPWA registration theme component name
+     */
+    const SCANDIPWA_COMPONENT_NAME = 'frontend/scandipwa/scandipwa';
+
+    /**
+     * @var ListInterface
+     */
+    protected $themeList;
+
+    /**
+     * @var ComponentRegistrarInterface
+     */
+    protected $componentRegistrar;
+
+    /**
+     * @var string|false
+     */
+    public $scandiPWAPackgeVersion;
+
+    /**
+     * Footer constructor.
+     * @param Context $context
+     * @param ProductMetadataInterface $productMetadata
+     * @param ListInterface $themeList
+     * @param ComponentRegistrarInterface $componentRegistrar
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        ProductMetadataInterface $productMetadata,
+        ListInterface $themeList,
+        ComponentRegistrarInterface $componentRegistrar,
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $productMetadata,
+            $data
+        );
+
+        $this->themeList = $themeList;
+        $this->componentRegistrar = $componentRegistrar;
+    }
+
+    /**
+     * Gets package.json file from ScandiPWA theme directory and sets in class properties its version
+     * In case if no version provided or theme directory doesn't exists, sets as false
+     */
+    public function getPackageJsonData() {
+        $pathToTheme = $this->getScandiPWADirectoryPath();
+
+        if (!$pathToTheme) {
+           $this->scandiPWAPackgeJsonData = false;
+           return;
+        }
+
+        // Since theme registration files are located in separate folder 'magento' we need to fallback one step
+        // where is located package.json file
+        $pathToTheme = substr($pathToTheme, 0, -7) . self::PACKAGE_JSON_FILE;
+
+        if (file_exists($pathToTheme)) {
+            $packageData = json_decode(file_get_contents($pathToTheme));
+            $this->scandiPWAPackgeVersion = $packageData->version ?? false;
+        } else {
+            $this->scandiPWAPackgeVersion = false;
+        }
+    }
+
+    /**
+     * Checks is ScandiPWA theme presents in theme list
+     * and gets it path to directory where it is located
+     *
+     * @return string|null
+     */
+    public function getScandiPWADirectoryPath() {
+        $themeDirectoryPath = null;
+
+        foreach ($this->themeList as $theme) {
+            if ($theme->getFullPath() === self::SCANDIPWA_COMPONENT_NAME) {
+                $themeDirectoryPath = $this->componentRegistrar->getPath(
+                    ComponentRegistrar::THEME,
+                    $theme->getFullPath()
+                );
+
+                break;
+            }
+        }
+
+        return $themeDirectoryPath;
+    }
+
+    /**
+     * @return string|false
+     */
+    public function getScandiPWAVersion() {
+        $this->getPackageJsonData();
+
+        return $this->scandiPWAPackgeVersion;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -12,4 +12,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="ScandiPWA\Locale\View\Result\Page" type="ScandiPWA\Customization\View\Result\Page" />
     <preference for="Magento\Theme\Model\Design\Backend\Favicon" type="ScandiPWA\Customization\Model\Design\Backend\Favicon" />
+    <preference for="Magento\Backend\Block\Page\Footer" type="ScandiPWA\Customization\Block\Page\Footer" />
 </config>

--- a/src/view/adminhtml/layout/default.xml
+++ b/src/view/adminhtml/layout/default.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Aleksandrs Kondratjevs <info@scandiweb.com>
+ * @copyright Copyright (c) 2021 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="version">
+            <action method="setTemplate">
+                <argument name="template" xsi:type="string">ScandiPWA_Customization::page/footer.phtml</argument>
+            </action>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/templates/page/footer.phtml
+++ b/src/view/adminhtml/templates/page/footer.phtml
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @category ScandiPWA
+ * @package ScandiPWA\Customization
+ * @author Aleksandrs Kondratjevs <info@scandiweb.com>
+ * @copyright Copyright (c) 2021 Scandiweb, Ltd (http://scandiweb.com)
+ * @license http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
+ */
+?>
+<?php if ($block->getScandiPWAVersion()) : ?>
+<p class="scandipwa-version">
+    <strong><?= $block->escapeHtml(__('ScandiPWA')) ?></strong>
+    <?= $block->escapeHtml(__('ver. %1', $block->scandiPWAPackgeVersion)) ?>
+</p>
+<?php endif; ?>
+<p class="magento-version">
+    <strong><?= $block->escapeHtml(__('Magento')) ?></strong>
+    <?= $block->escapeHtml(__('ver. %1', $block->getMagentoVersion())) ?>
+</p>


### PR DESCRIPTION
fixes scandipwa/scandipwa#3361

In this PR we implement displaying theme version on adminhtml footer.  Since right now we don't have correctly working composer.json in theme, decided to get package.json file and read version if it presents. In other cases just don't render anything.
In future when it will be possible to set correct version in composer.json will be great to just remove exist functionality and get correct version from composer packages. 