### PR TITLE
[4123] Change of default start_url parameter to support analytics

### DIFF
--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -37,7 +37,7 @@
                 <background_color>ffffff</background_color>
                 <lang>en-US</lang>
                 <theme_color>ffffff</theme_color>
-                <start_url>/</start_url>
+                <start_url>/?utm_source=homescreen&amp;utm_medium=scandiPWA</start_url>
                 <display>standalone</display>
                 <orientation>portrait</orientation>
                 <scope>/</scope>


### PR DESCRIPTION
**Original issue:** 

- Fixes https://github.com/scandipwa/scandipwa/issues/4123

**In this PR:** 

- Change of default start_url parameter to support analytics