### PR TITLE
#3718 Deleted the Promotion CMS block below the menu setting from the admin panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "scandipwa/customization",
     "description": "Customization configuration for ScandiPWA",
     "type": "magento2-module",
-    "license": [
+    "version": "1.5.10",
+     "license": [
         "OSL-3.0"
     ],
     "require": {

--- a/src/etc/adminhtml/system/content.xml
+++ b/src/etc/adminhtml/system/content.xml
@@ -70,11 +70,6 @@
                 <source_model>ScandiPWA\Customization\Model\Menu\Source\Menu</source_model>
             </field>
 
-            <field id="header_cms" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Promotion CMS block</label>
-                <comment>The block displayed bellow the menu.</comment>
-                <source_model>ScandiPWA\Customization\Model\Block\Source\Block</source_model>
-            </field>
 
             <field id="contacts_cms" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Promotion CMS block</label>


### PR DESCRIPTION
**Related Issue(s):**

- Fixes  https://github.com/scandipwa/scandipwa/issues/3718 

**Problem:**
- Header block above/below the menu is missing on FE after the redesign.

**In this PR**

- Delete setting for Header block below menu in Admin panel
  Stores -> Configuration -> Content customization -> Header and Menu -> Promotion CMS block (bellow menu)
- Modified file path: customization/src/etc/adminhtml/system/content.xml