### PR TITLE
Removed version field from the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "scandipwa/customization",
     "description": "Customization configuration for ScandiPWA",
     "type": "magento2-module",
-    "version": "1.5.10",
      "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Removed version field from the composer.json in order to fix releases on Packagist.