### PR TITLE
[4051] - scandiPWA version in footer is hardcoded - fixed

### DIFF
--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -20,12 +20,7 @@ use Magento\Framework\View\Design\Theme\ListInterface;
 class Footer extends CoreFooter
 {
     const PACKAGE_JSON_FILE = 'package.json';
-
-    /**
-     * ScandiPWA registration theme component name
-     */
-    const SCANDIPWA_COMPONENT_NAME = 'frontend/scandipwa/scandipwa';
-
+    
     /**
      * @var ListInterface
      */
@@ -52,6 +47,7 @@ class Footer extends CoreFooter
      * @param ProductMetadataInterface $productMetadata
      * @param ListInterface $themeList
      * @param ComponentRegistrarInterface $componentRegistrar
+     * @param ResourceConnection $resourceConnection
      * @param array $data
      */
     public function __construct(
@@ -68,6 +64,7 @@ class Footer extends CoreFooter
             $data
         );
 
+        $this->resourceConnection = $resourceConnection;
         $this->themeList = $themeList;
         $this->componentRegistrar = $componentRegistrar;
     }
@@ -88,14 +85,9 @@ class Footer extends CoreFooter
         // where is located package.json file
         $pathToTheme = substr($pathToTheme, 0, -7) . self::PACKAGE_JSON_FILE;
 
-        // $connection =  $this->$resourceConnection->$getConnection();
-        // $query ="SELECT * FROM core_config_data WHERE config_id = 37";
-        // $themeid = $connection->fetchAll(query);
-
         if (file_exists($pathToTheme)) {
             $packageData = json_decode(file_get_contents($pathToTheme), true);
-            $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
-            // $this->scandiPWAPackgeVersion = $themeid->value;
+             $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
         } else {
             $this->scandiPWAPackgeVersion = false;
         }
@@ -110,8 +102,14 @@ class Footer extends CoreFooter
     public function getScandiPWADirectoryPath() {
         $themeDirectoryPath = null;
 
+        $connection =  $this->resourceConnection->getConnection();
+        $themeid_query = "SELECT value FROM core_config_data WHERE config_id = 37";
+        $themeid = $connection->fetchAll($themeid_query);
+        $applied_theme_query = "SELECT * FROM theme WHERE theme_id = " . $themeid[0]['value'];
+        $applied_theme = $connection->fetchAll($applied_theme_query);
+
         foreach ($this->themeList as $theme) {
-            if ($theme->getFullPath() === self::SCANDIPWA_COMPONENT_NAME) {
+            if ($theme->getFullPath() === "frontend/" . $applied_theme[0]['theme_path']) {
                 $themeDirectoryPath = $this->componentRegistrar->getPath(
                     ComponentRegistrar::THEME,
                     $theme->getFullPath()

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -102,7 +102,7 @@ class Footer extends CoreFooter
     public function getScandiPWADirectoryPath() {
         $themeDirectoryPath = null;
 
-        $connection =  $this->resourceConnection->getConnection();
+        $connection = $this->resourceConnection->getConnection();
         $themeid_query = "SELECT value FROM core_config_data WHERE config_id = 37";
         $themeid = $connection->fetchAll($themeid_query);
         $applied_theme_query = "SELECT * FROM theme WHERE theme_id = " . $themeid[0]['value'];

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -12,6 +12,7 @@ namespace ScandiPWA\Customization\Block\Page;
 use Magento\Backend\Block\Page\Footer as CoreFooter;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\Design\Theme\ListInterface;
@@ -29,6 +30,11 @@ class Footer extends CoreFooter
      * @var ListInterface
      */
     protected $themeList;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
 
     /**
      * @var ComponentRegistrarInterface
@@ -53,6 +59,7 @@ class Footer extends CoreFooter
         ProductMetadataInterface $productMetadata,
         ListInterface $themeList,
         ComponentRegistrarInterface $componentRegistrar,
+        ResourceConnection $resourceConnection,
         array $data = []
     ) {
         parent::__construct(
@@ -81,9 +88,14 @@ class Footer extends CoreFooter
         // where is located package.json file
         $pathToTheme = substr($pathToTheme, 0, -7) . self::PACKAGE_JSON_FILE;
 
+        // $connection =  $this->$resourceConnection->$getConnection();
+        // $query ="SELECT * FROM core_config_data WHERE config_id = 37";
+        // $themeid = $connection->fetchAll(query);
+
         if (file_exists($pathToTheme)) {
             $packageData = json_decode(file_get_contents($pathToTheme), true);
             $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
+            // $this->scandiPWAPackgeVersion = $themeid->value;
         } else {
             $this->scandiPWAPackgeVersion = false;
         }

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -87,9 +87,9 @@ class Footer extends CoreFooter
 
         if (file_exists($pathToTheme)) {
             $packageData = json_decode(file_get_contents($pathToTheme), true);
-             $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
+            $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
         } else {
-            $this->scandiPWAPackgeVersion = "not selected";
+            $this->scandiPWAPackgeVersion = "n/a";
         }
     }
 
@@ -104,7 +104,7 @@ class Footer extends CoreFooter
 
         $connection = $this->resourceConnection->getConnection();
         // fetch the id of the currently applied theme
-        $themeid_query = "SELECT value FROM core_config_data WHERE config_id = 37";
+        $themeid_query = "SELECT value FROM core_config_data WHERE path = 'design/theme/theme_id' AND scope_id = 0";
         $themeid = $connection->fetchAll($themeid_query);
         // use this id to fetch the applied theme itself
         $applied_theme_query = "SELECT * FROM theme WHERE theme_id = " . $themeid[0]['value'];

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -21,6 +21,11 @@ class Footer extends CoreFooter
     const PACKAGE_JSON_FILE = 'package.json';
 
     /**
+     * ScandiPWA registration theme component name
+     */
+    const SCANDIPWA_COMPONENT_NAME = 'frontend/scandipwa';
+
+    /**
      * @var ListInterface
      */
     protected $themeList;
@@ -80,7 +85,7 @@ class Footer extends CoreFooter
             $packageData = json_decode(file_get_contents($pathToTheme), true);
             $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
         } else {
-            $this->scandiPWAPackgeVersion = "n/a";
+            $this->scandiPWAPackgeVersion = 'n/a';
         }
     }
 
@@ -94,7 +99,7 @@ class Footer extends CoreFooter
         $themeDirectoryPath = null;
 
         foreach ($this->themeList as $theme) {
-            if (str_contains($theme->getFullPath(), "frontend/scandipwa")) {
+            if (str_contains($theme->getFullPath(), self::SCANDIPWA_COMPONENT_NAME)) {
                 $themeDirectoryPath = $this->componentRegistrar->getPath(
                     ComponentRegistrar::THEME,
                     $theme->getFullPath()

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -12,7 +12,6 @@ namespace ScandiPWA\Customization\Block\Page;
 use Magento\Backend\Block\Page\Footer as CoreFooter;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\ProductMetadataInterface;
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\Design\Theme\ListInterface;
@@ -25,11 +24,6 @@ class Footer extends CoreFooter
      * @var ListInterface
      */
     protected $themeList;
-
-    /**
-     * @var ResourceConnection
-     */
-    protected $resourceConnection;
 
     /**
      * @var ComponentRegistrarInterface
@@ -47,7 +41,6 @@ class Footer extends CoreFooter
      * @param ProductMetadataInterface $productMetadata
      * @param ListInterface $themeList
      * @param ComponentRegistrarInterface $componentRegistrar
-     * @param ResourceConnection $resourceConnection
      * @param array $data
      */
     public function __construct(
@@ -55,7 +48,6 @@ class Footer extends CoreFooter
         ProductMetadataInterface $productMetadata,
         ListInterface $themeList,
         ComponentRegistrarInterface $componentRegistrar,
-        ResourceConnection $resourceConnection,
         array $data = []
     ) {
         parent::__construct(
@@ -64,7 +56,6 @@ class Footer extends CoreFooter
             $data
         );
 
-        $this->resourceConnection = $resourceConnection;
         $this->themeList = $themeList;
         $this->componentRegistrar = $componentRegistrar;
     }
@@ -102,16 +93,8 @@ class Footer extends CoreFooter
     public function getScandiPWADirectoryPath() {
         $themeDirectoryPath = null;
 
-        $connection = $this->resourceConnection->getConnection();
-        // fetch the id of the currently applied theme
-        $themeid_query = "SELECT value FROM core_config_data WHERE path = 'design/theme/theme_id' AND scope_id = 0";
-        $themeid = $connection->fetchAll($themeid_query);
-        // use this id to fetch the applied theme itself
-        $applied_theme_query = "SELECT * FROM theme WHERE theme_id = " . $themeid[0]['value'];
-        $applied_theme = $connection->fetchAll($applied_theme_query);
-
         foreach ($this->themeList as $theme) {
-            if ($theme->getFullPath() === "frontend/" . $applied_theme[0]['theme_path']) {
+            if (str_contains($theme->getFullPath(), "frontend/scandipwa")) {
                 $themeDirectoryPath = $this->componentRegistrar->getPath(
                     ComponentRegistrar::THEME,
                     $theme->getFullPath()

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -20,7 +20,7 @@ use Magento\Framework\View\Design\Theme\ListInterface;
 class Footer extends CoreFooter
 {
     const PACKAGE_JSON_FILE = 'package.json';
-    
+
     /**
      * @var ListInterface
      */
@@ -89,7 +89,7 @@ class Footer extends CoreFooter
             $packageData = json_decode(file_get_contents($pathToTheme), true);
              $this->scandiPWAPackgeVersion = $this->getScandiPWAFromPackageData($packageData);
         } else {
-            $this->scandiPWAPackgeVersion = false;
+            $this->scandiPWAPackgeVersion = "not selected";
         }
     }
 

--- a/src/Block/Page/Footer.php
+++ b/src/Block/Page/Footer.php
@@ -103,8 +103,10 @@ class Footer extends CoreFooter
         $themeDirectoryPath = null;
 
         $connection = $this->resourceConnection->getConnection();
+        // fetch the id of the currently applied theme
         $themeid_query = "SELECT value FROM core_config_data WHERE config_id = 37";
         $themeid = $connection->fetchAll($themeid_query);
+        // use this id to fetch the applied theme itself
         $applied_theme_query = "SELECT * FROM theme WHERE theme_id = " . $themeid[0]['value'];
         $applied_theme = $connection->fetchAll($applied_theme_query);
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4051

**Problem:**
* The theme version in the footer only displays if the theme is called a particular way

**In this PR:**
* Fetching the applied theme path from the db
* Checking if the applied theme has a package.json with scandipwa dependency
* If yes, display its version. If not, display "not selected"