### PR TITLE
#4277 Return `website_code` in Page.php for using in FE

### DIFF
--- a/src/View/Result/Page.php
+++ b/src/View/Result/Page.php
@@ -158,7 +158,16 @@ class Page extends LocalePage
     /**
      * @return array[]
      */
-    public function getAppIconData() {
+    public function getAppIconData()
+    {
         return $this->appIcon->getIconLinks();
+    }
+
+    /**
+     * @return string
+     */
+    public function getWebsiteCode()
+    {
+        return $this->storeManager->getWebsite()->getCode();
     }
 }


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/4277

**Problem:**
* User's `quoteId` wasn't being updated properly when changing between websites' stores, that needed global variable `window.website_code` to handle token change and update correctly

**In this PR:**
* I modified `Page.php` to return website code from `storeManager`
