### PR TITLE
Fixed adminhtml datepicker show method patch

### DIFF
--- a/src/view/adminhtml/web/js/datepicker.js
+++ b/src/view/adminhtml/web/js/datepicker.js
@@ -1,7 +1,7 @@
 //This script fixes incorrect positioning in modal datepickers.
 //This file should be removed after magento fixes the datepickers.
 
-require(['jquery'], ($) => {
+require(['jquery', 'jquery/ui'], ($) => {
     $(window).on('load', () => {
         const show = $.datepicker._showDatepicker;
         if (show) {


### PR DESCRIPTION
Fixes scandipwa/scandipwa#4925

Fixed adminhtml datepicker show method patch.
The custom script was loaded before the `jquery/ui` was initialized.
Postponed this by adding the `jquery/ui` as a dependency.