### PR TITLE
#5042 Created `getAccountSharingOption` function to return config option for using in FE

### DIFF
--- a/src/View/Result/Page.php
+++ b/src/View/Result/Page.php
@@ -170,4 +170,10 @@ class Page extends LocalePage
     {
         return $this->storeManager->getWebsite()->getCode();
     }
+
+    public function getAccountSharingOption()
+    {
+        $optionValue = $this->scopeConfig->getValue('customer/account_share/scope', ScopeInterface::SCOPE_WEBSITE);
+        return $optionValue == "0" ? "global" : "per_website";
+    }
 }

--- a/src/View/Result/Page.php
+++ b/src/View/Result/Page.php
@@ -174,6 +174,6 @@ class Page extends LocalePage
     public function getAccountSharingOption()
     {
         $optionValue = $this->scopeConfig->getValue('customer/account_share/scope', ScopeInterface::SCOPE_WEBSITE);
-        return $optionValue == "0" ? "global" : "per_website";
+        return (int)$optionValue == 0 ? 'global' : 'per_website';
     }
 }


### PR DESCRIPTION
**Related**
* Issue: https://github.com/scandipwa/scandipwa/issues/5042
* FE: https://github.com/scandipwa/scandipwa/pull/5069

Function `getAccountSharingOption` is needed to figure out on FE whether localstorage data needs to be stored globally or per website.

Returns `"global"` if `Customer Account Sharing` in Magento config is global and returns `"per_website"` if its per website.